### PR TITLE
Fix timestamp in collected data, to be compliant with ISO8601

### DIFF
--- a/pshitt
+++ b/pshitt
@@ -97,7 +97,7 @@ class Server (paramiko.ServerInterface):
         else:
             data['src_ip'] = self.addr
         data['src_port'] = self.port
-        data['timestamp'] = datetime.isoformat(datetime.now())
+        data['timestamp'] = datetime.isoformat(datetime.utcnow())
         try:
             rversion = self.transport.remote_version.split('-', 2)[2]
             data['software_version'] = rversion


### PR DESCRIPTION
DISCLAIMER: this update can break existing log processing chains, like the
ELK stack.

The logged timestamp is expected to be ISO8601 compliant, to be easy to
parse with log processing chains.
However, before this fix, the logged timestamp represented the _local time_
and was not ISO8601 compliant.
To solve this problem, this fix aims at logging a _UTC_ timestamp, which is
ISO8601 compliant.
In other words, the collected timestamp is now less human readable and more
processing chain friendly.
