### PR TITLE
Issue 8

### DIFF
--- a/pshitt.py
+++ b/pshitt.py
@@ -152,7 +152,6 @@ class Pshitt(object):
         self.host_key = paramiko.RSAKey(filename=self.args.key)
 
     def run(self, args):
-        logging.info('Starting SSH server')
         # now connect
         try:
             sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)

--- a/pshitt.py
+++ b/pshitt.py
@@ -233,8 +233,10 @@ def main():
     server = Pshitt(args)
     if args.daemon:
         with daemon.DaemonContext():
+            logging.basicConfig(filename=args.log, level=logging.DEBUG if args.verbose else logging.INFO)
             server.run(args)
     else:
+        logging.basicConfig(filename=args.log, level=logging.DEBUG if args.verbose else logging.INFO)
         server.run(args)
 
 


### PR DESCRIPTION
To resolve the issue with running in daemon mode, we need to ensure that logging is properly initialized within the daemon context. We will move the logging setup inside the daemon context block to ensure it is properly configured when running as a daemon.
Modify the daemon context block to ensure that the logging and SSH server initialization are properly handled. Move the logging setup inside the daemon context block.